### PR TITLE
Guard smooth scroll querySelector against empty hash

### DIFF
--- a/index.html
+++ b/index.html
@@ -608,17 +608,26 @@
             document.querySelectorAll('a[href^="#"]').forEach(anchor => {
                 anchor.addEventListener('click', function (e) {
                     const href = this.getAttribute('href');
-                    if (document.querySelector(href) && document.querySelector(href).classList.contains('modal')) {
+                    if (!href) {
                         return;
                     }
-                    e.preventDefault();
+
+                    if (href === '#') {
+                        e.preventDefault();
+                        window.scrollTo({ top: 0, behavior: 'smooth' });
+                        return;
+                    }
+
                     const targetElement = document.querySelector(href);
+                    if (targetElement && targetElement.classList.contains('modal')) {
+                        return;
+                    }
+
                     if (targetElement) {
+                        e.preventDefault();
                         targetElement.scrollIntoView({
                             behavior: 'smooth'
                         });
-                    } else if (href === '#') {
-                         window.scrollTo({ top: 0, behavior: 'smooth' });
                     }
                 });
             });


### PR DESCRIPTION
## Summary
- ensure the smooth-scroll handler scrolls to top when the brand link points to `#`
- avoid invoking `document.querySelector` with an invalid selector while keeping the modal guard in place

## Testing
- python - <<'PY'  # playwright smooth-scroll verification

------
https://chatgpt.com/codex/tasks/task_b_68d05823a12c832cbdac62f144fc313b